### PR TITLE
Remove custom type in exported function parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ const jobId = "abc123...";
 const isActive = await warpSdk.isJobActive(jobId)
 console.log(`Job is ${isActive ? "active" : "inactive"}.`)
 ```
+
+## Tips
+Whenever you work with `CosmosMsg` (e.g. when you create a job, you need to specify a list of `CosmosMsg` to execute for this job), make sure to encode it with `base64encode` in sdk. There's also `base64decode` in sdk for you to decode `CosmosMsg` when you get `job.msgs`.
+
+```typescript
+import { base64encode } from '@terra-money/warp-sdk';
+const msg = {
+  bank: {
+    send: {
+      amount: [{ denom: 'uluna', amount: '100000' }],
+      to_address: 'receiver address',
+    },
+  },
+};
+const base64EncodedMsg = base64encode(msg);
+const createJobMsg = {
+  ....,
+  msgs: [base64EncodedMsg],
+};
+const job = await warpSdk.createJob('sender address', msg);
+console.log(job);
+```
+
 ## Methods
 
 isJobActive(jobId: string): Promise<boolean>: Check if a job is active by its ID.

--- a/README.md
+++ b/README.md
@@ -23,29 +23,6 @@ const jobId = "abc123...";
 const isActive = await warpSdk.isJobActive(jobId)
 console.log(`Job is ${isActive ? "active" : "inactive"}.`)
 ```
-
-## Tips
-Whenever you work with `CosmosMsg` (e.g. when you create a job, you need to specify a list of `CosmosMsg` to execute for this job), make sure to encode it with `base64encode` in sdk. There's also `base64decode` in sdk for you to decode `CosmosMsg` when you get `job.msgs`.
-
-```typescript
-import { base64encode } from '@terra-money/warp-sdk';
-const msg = {
-  bank: {
-    send: {
-      amount: [{ denom: 'uluna', amount: '100000' }],
-      to_address: 'receiver address',
-    },
-  },
-};
-const base64EncodedMsg = base64encode(msg);
-const createJobMsg = {
-  ....,
-  msgs: [base64EncodedMsg],
-};
-const job = await warpSdk.createJob('sender address', msg);
-console.log(job);
-```
-
 ## Methods
 
 isJobActive(jobId: string): Promise<boolean>: Check if a job is active by its ID.
@@ -130,9 +107,18 @@ createJob(sender: string, msg: CreateJobMsg): Promise<TxInfo>: Create a job.
 ```typescript
 const warpSdk = new WarpSdk(wallet, contractAddress);
 
+const cosmosMsg = {
+  bank: {
+    send: {
+      amount: [{ denom: 'uluna', amount: '100000' }],
+      to_address: 'receiver address',
+    },
+  },
+};
+
 const msg = {
   ....,
-  msgs: [...],
+  msgs: [JSON.stringify(cosmosMsg)],
   reward: '1000000',
   condition: {
     and: [{

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,5 +1,4 @@
 import { warp_controller } from 'types/contracts';
-import { base64encode } from 'utils';
 
 export class JobSequenceMsgBuilder {
   static new() {
@@ -36,31 +35,3 @@ export class JobSequenceMsgBuilder {
     return this.chainSequence(0);
   }
 }
-
-export type WasmMsg = Extract<warp_controller.CosmosMsgFor_Empty, { wasm: {} }>;
-export type WasmExecuteMsg = { wasm: Extract<WasmMsg['wasm'], { execute: {} }> };
-
-export const createJobMsg = (contractAddr: string, msg: warp_controller.CreateJobMsg): WasmExecuteMsg => {
-  return {
-    wasm: {
-      execute: {
-        contract_addr: contractAddr,
-        msg: base64encode(msg),
-        funds: [],
-      },
-    },
-  };
-};
-
-export type CreateJobMsg = Omit<warp_controller.CreateJobMsg, 'msgs'> & {
-  msgs: warp_controller.CosmosMsgFor_Empty[];
-};
-
-export const jsonifyMsgs = (msg: CreateJobMsg): warp_controller.CreateJobMsg => {
-  const { msgs, ...rest } = msg;
-
-  return {
-    ...rest,
-    msgs: msgs.map((msg) => JSON.stringify(msg)),
-  };
-};

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -5,7 +5,7 @@ import { base64encode, contractQuery, LUNA, Token, TransferMsg } from 'utils';
 import { CreateTxOptions, TxInfo } from '@terra-money/terra.js';
 import { TxBuilder } from 'tx';
 import Big from 'big.js';
-import { CreateJobMsg, JobSequenceMsgBuilder, jsonifyMsgs } from 'job';
+import { JobSequenceMsgBuilder } from 'job';
 import { resolveExternalInputs } from 'variables';
 
 export class WarpSdk {
@@ -96,7 +96,7 @@ export class WarpSdk {
     return config;
   }
 
-  public async createJob(sender: string, msg: CreateJobMsg): Promise<TxInfo> {
+  public async createJob(sender: string, msg: warp_controller.CreateJobMsg): Promise<TxInfo> {
     await this.createAccountIfNotExists(sender);
 
     const account = await this.account(sender);
@@ -107,7 +107,7 @@ export class WarpSdk {
         [LUNA.denom]: Big(msg.reward).mul(Big(config.creation_fee_percentage).add(100).div(100)).toString(),
       })
       .execute<Extract<warp_controller.ExecuteMsg, { create_job: {} }>>(sender, this.contractAddress, {
-        create_job: jsonifyMsgs(msg),
+        create_job: msg,
       })
       .build();
 
@@ -128,7 +128,7 @@ export class WarpSdk {
    *            when cond3 active
    *            then execute job3
    */
-  public async createJobSequence(sender: string, sequence: CreateJobMsg[]): Promise<TxInfo> {
+  public async createJobSequence(sender: string, sequence: warp_controller.CreateJobMsg[]): Promise<TxInfo> {
     await this.createAccountIfNotExists(sender);
 
     const account = await this.account(sender);
@@ -137,8 +137,7 @@ export class WarpSdk {
     let jobSequenceMsgBuilder = JobSequenceMsgBuilder.new();
     let totalReward = Big(0);
 
-    sequence.forEach((input) => {
-      const msg = jsonifyMsgs(input);
+    sequence.forEach((msg) => {
       totalReward = totalReward.add(Big(msg.reward));
       jobSequenceMsgBuilder = jobSequenceMsgBuilder.chain(msg);
     });


### PR DESCRIPTION
Only use generated types in exported function parameters to keep things consistent.

This change will break whoever is using warp-sdk's `createJob` and `createJobSequence` function when they upgrade the sdk version. However I don't think there's that many people using it now, so it should be ok.