### PR TITLE
fix import syntax

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -14,7 +14,7 @@ import {
   Wallet,
 } from '@terra-money/terra.js';
 import { WarpSdk } from './sdk';
-import { warp_controller } from 'types/contracts';
+import { warp_controller } from './types/contracts';
 
 dotenv.config();
 

--- a/src/condition.ts
+++ b/src/condition.ts
@@ -1,10 +1,10 @@
-import { warp_controller } from 'types/contracts';
+import { warp_controller } from './types/contracts';
 import { every, some } from 'lodash';
 import * as jsonpath from 'jsonpath';
-import { contractQuery } from 'utils';
+import { contractQuery } from './utils';
 import { Big } from 'big.js';
-import { Wallet } from 'wallet';
-import { extractVariableName, resolveExternalVariable, variableName } from 'variables';
+import { Wallet } from './wallet';
+import { extractVariableName, resolveExternalVariable, variableName } from './variables';
 
 export class Condition {
   public wallet: Wallet;

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,4 +1,4 @@
-import { warp_controller } from 'types/contracts';
+import { warp_controller } from './types/contracts';
 
 export class JobSequenceMsgBuilder {
   static new() {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,12 +1,12 @@
-import { warp_account, warp_controller } from 'types/contracts';
+import { warp_account, warp_controller } from './types/contracts';
 import { WalletLike, Wallet, wallet } from './wallet';
-import { Condition } from 'condition';
-import { base64encode, contractQuery, LUNA, Token, TransferMsg } from 'utils';
+import { Condition } from './condition';
+import { base64encode, contractQuery, LUNA, Token, TransferMsg } from './utils';
 import { CreateTxOptions, TxInfo } from '@terra-money/terra.js';
-import { TxBuilder } from 'tx';
+import { TxBuilder } from './tx';
 import Big from 'big.js';
-import { JobSequenceMsgBuilder } from 'job';
-import { resolveExternalInputs } from 'variables';
+import { JobSequenceMsgBuilder } from './job';
+import { resolveExternalInputs } from './variables';
 
 export class WarpSdk {
   public wallet: Wallet;

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,4 +1,4 @@
-import { warp_controller } from 'types';
+import { warp_controller } from './types';
 import * as jsonpath from 'jsonpath';
 import axios from 'axios';
 


### PR DESCRIPTION
cannot resolve `warpSdk.condition.resolveCond()` because `condition` is imported in this way
```import { Condition } from 'condition';```
rather than
```import { Condition } from './condition';```